### PR TITLE
add S3TargetInfo for AWS S3

### DIFF
--- a/sciluigi/__init__.py
+++ b/sciluigi/__init__.py
@@ -10,6 +10,7 @@ from sciluigi.audit import AuditTrailHelpers
 
 from sciluigi import dependencies
 from sciluigi.dependencies import TargetInfo
+from sciluigi.dependencies import S3TargetInfo
 from sciluigi.dependencies import DependencyHelpers
 
 from sciluigi import interface

--- a/sciluigi/dependencies.py
+++ b/sciluigi/dependencies.py
@@ -30,6 +30,14 @@ class TargetInfo(object):
 
 # ==============================================================================
 
+class S3TargetInfo(TargetInfo):
+    def __init__(self, task, path, format=None, client=None):
+        self.task = task
+        self.path = path
+        self.target = luigi.s3.S3Target(path, format=format, client=client)
+
+# ==============================================================================
+
 class DependencyHelpers(object):
     '''
     Mixin implementing methods for supporting dynamic, and target-based


### PR DESCRIPTION
This allows reading and writing to S3.

```
class S3FooReader(sciluigi.ExternalTask):
    def out_foo(self):
        return sciluigi.S3TargetInfo(self, 's3://my-bucket/test/foo.txt')
```